### PR TITLE
Updated sensors DB with Canon 90D

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -597,6 +597,7 @@ Canon;Canon EOS 8000D;22.3;digicamdb
 Canon;Canon EOS 800D;22.3;digicamdb,imaging-resource,dxomark
 Canon;Canon EOS 80D;22.5;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS 9000D;22.3;digicamdb
+Canon;Canon EOS 90D;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS D30;22.7;dpreview,digicamdb
 Canon;Canon EOS D60;22.7;dpreview,digicamdb
 Canon;Canon EOS Digital Rebel;22.7;dpreview,digicamdb


### PR DESCRIPTION
Added Canon 90D with 22.3mm sensor width.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [X ] Added Canon 90D to sensor database
-->


## Implementation remarks


<!--
Added 90D sensor width, with features copied from 80D. Sensor width from Canon specifications.
-->

